### PR TITLE
TC_01.001.13 | New Item > Creatе a new item > Verify that an error appears after entering special characters in item name

### DIFF
--- a/tests/test_multi_configuration_project.py
+++ b/tests/test_multi_configuration_project.py
@@ -48,10 +48,15 @@ def test_verify_enable_toogle_has_tooltip(browser):
 ])
 def test_create_item_with_special_characters(browser, special_characters):
     browser.find_element(By.XPATH, "//a[@href='/view/all/newJob']").click()
+    browser.find_element(By.CLASS_NAME, "hudson_matrix_MatrixProject").click()
 
     browser.find_element(By.ID, "name").send_keys(f"{multiconfiguration_project_name}{special_characters}")
 
     error_message = WebDriverWait(browser, 5).until(
         EC.visibility_of_element_located((By.ID, "itemname-invalid"))).text
 
-    assert error_message == f"» ‘{special_characters}’ is an unsafe character"
+    expected_error_message = f"‘{special_characters}’ is an unsafe character"
+    assert error_message == "» " + f"‘{special_characters}’ is an unsafe character"
+
+    browser.find_element(By.ID, "ok-button").click()
+    assert browser.find_element(By.TAG_NAME, "p").text == expected_error_message

--- a/tests/test_multi_configuration_project.py
+++ b/tests/test_multi_configuration_project.py
@@ -1,5 +1,6 @@
 import time
 
+import pytest
 from selenium.webdriver import ActionChains
 from selenium.webdriver.support import expected_conditions as EC
 from selenium.webdriver.common.by import By
@@ -41,3 +42,16 @@ def test_verify_enable_toogle_has_tooltip(browser):
         EC.visibility_of_element_located((By.CLASS_NAME, "tippy-content"))).text
 
     assert toggle_tooltip == "Enable or disable the current project"
+
+@pytest.mark.parametrize("special_characters ",[
+    "!", "%", "&", "#", "@", "*", "$", "?", "^", "|", "/", "]", "["
+])
+def test_create_item_with_special_characters(browser, special_characters):
+    browser.find_element(By.XPATH, "//a[@href='/view/all/newJob']").click()
+
+    browser.find_element(By.ID, "name").send_keys(f"{multiconfiguration_project_name}{special_characters}")
+
+    error_message = WebDriverWait(browser, 5).until(
+        EC.visibility_of_element_located((By.ID, "itemname-invalid"))).text
+
+    assert error_message == f"» ‘{special_characters}’ is an unsafe character"

--- a/tests/test_multi_configuration_project.py
+++ b/tests/test_multi_configuration_project.py
@@ -6,7 +6,7 @@ from selenium.webdriver.support import expected_conditions as EC
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support.wait import WebDriverWait
 
-multiconfiguration_project_name = "MultiConfig_Name"
+multiconfiguration_project_name = "MultiConfigName"
 
 def test_verify_status_switching_enable_button(browser):
     browser.find_element(By.XPATH, "//a[@href='/view/all/newJob']").click()
@@ -44,15 +44,15 @@ def test_verify_enable_toogle_has_tooltip(browser):
     assert toggle_tooltip == "Enable or disable the current project"
 
 @pytest.mark.parametrize("special_characters ",[
-    "!", "%", "&", "#", "@", "*", "$", "?", "^", "|", "/", "]", "["
+    "!", "%", "&", "#", "@", "*", "?", "^", "|", "/", "]", "["
 ])
 def test_create_item_with_special_characters(browser, special_characters):
     browser.find_element(By.XPATH, "//a[@href='/view/all/newJob']").click()
-    browser.find_element(By.CLASS_NAME, "hudson_matrix_MatrixProject").click()
 
     browser.find_element(By.ID, "name").send_keys(f"{multiconfiguration_project_name}{special_characters}")
+    browser.find_element(By.CLASS_NAME, "hudson_matrix_MatrixProject").click()
 
-    error_message = WebDriverWait(browser, 5).until(
+    error_message = WebDriverWait(browser, 10).until(
         EC.visibility_of_element_located((By.ID, "itemname-invalid"))).text
 
     expected_error_message = f"‘{special_characters}’ is an unsafe character"


### PR DESCRIPTION
Description: Check that keyboard special characters cannot be used in the item's name