### PR TITLE
AT_22.002.02 | Add Credentials > Username with Password > Create duplicate ID

### DIFF
--- a/tests/test_credentials.py
+++ b/tests/test_credentials.py
@@ -1,7 +1,4 @@
-import time
-
 import pytest
-from selenium.webdriver import Keys
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support.wait import WebDriverWait
 
@@ -30,6 +27,7 @@ def create_credential(driver, username, password, description, credential_id, tr
 
     driver.find_element(By.ID, "cr-dialog-submit").click()
 
+
 def navigate_to_credential_form(driver):
     driver.find_element(By.XPATH, "//*[@href = '/manage']").click()
     driver.find_element(By.XPATH, "//*[@href ='credentials']").click()
@@ -49,6 +47,7 @@ def find_credential_card(driver, username=None, description=None, credential_id=
             f'[.//span[contains(text(),"{description}")]])[1]'
         )
         return driver.find_element(By.XPATH, card_found_by_username_and_description)
+
 
 @pytest.mark.dependency()
 def test_create(browser):
@@ -80,23 +79,3 @@ def test_create_duplicate_id_error_validation(browser):
     )
 
     assert actual_error == expected_error
-
-
-@pytest.mark.dependency(depends=["test_create"])
-def test_create_duplicate_id_notification(browser):
-    expected_notification = "Credentials with specified ID already exist"
-
-    navigate_to_credential_form(browser)
-
-    browser.find_element(By.NAME, "_.id").send_keys(CREDENTIAL_ID)
-    browser.find_element(By.ID, "cr-dialog-submit").click()
-
-    actual_notification = WebDriverWait(browser, 15).until(
-        lambda d: d.execute_script("""
-                var el = document.getElementById('notification-bar');
-                return el ? el.innerText : '';
-            """)
-    )
-
-    assert actual_notification == expected_notification, \
-        f"Notification message mismatch. Expected: '{expected_notification}', Actual: '{actual_notification}'"

--- a/tests/test_credentials.py
+++ b/tests/test_credentials.py
@@ -1,3 +1,5 @@
+import pytest
+from selenium.webdriver import Keys
 from selenium.webdriver.common.by import By
 
 USERNAME = "Name"
@@ -25,6 +27,13 @@ def create_credential(driver, username, password, description, credential_id, tr
 
     driver.find_element(By.ID, "cr-dialog-submit").click()
 
+def navigate_to_credential_form(driver):
+    driver.find_element(By.XPATH, "//*[@href = '/manage']").click()
+    driver.find_element(By.XPATH, "//*[@href ='credentials']").click()
+    driver.find_element(By.XPATH, "//button[contains(text(), 'Add Credentials')]").click()
+    driver.find_element(By.XPATH, "//div[text() = 'Username with password']").click()
+    driver.find_element(By.ID, "cr-dialog-next").click()
+
 
 def find_credential_card(driver, username=None, description=None, credential_id=None, treat_as_secret=False):
     if treat_as_secret:
@@ -38,6 +47,7 @@ def find_credential_card(driver, username=None, description=None, credential_id=
         )
         return driver.find_element(By.XPATH, card_found_by_username_and_description)
 
+@pytest.mark.dependency()
 def test_create(browser):
     create_credential(browser, USERNAME, PASSWORD, DESCRIPTION, CREDENTIAL_ID, treat_as_secret=False)
 
@@ -50,3 +60,20 @@ def test_create(browser):
     )
 
     assert credential_card.is_displayed(), "Credential card was not found or not visible"
+
+@pytest.mark.dependency(depends=["test_create"])
+def test_create_duplicate_id(browser):
+    expected_error = "This ID is already in use"
+    expected_notification_bar_message = "Credentials with specified ID already exist"
+
+    navigate_to_credential_form(browser)
+
+    browser.find_element(By.NAME, "_.id").send_keys(CREDENTIAL_ID + Keys.TAB)
+    actual_error = browser.find_element(By.XPATH, "//div[@class = 'error']").text
+
+    browser.find_element(By.ID, "cr-dialog-submit").click()
+    actual_notification_bar_message = browser.find_element(By.ID, "notification-bar").text
+
+    assert actual_error == expected_error, f"Error message mismatch: expected '{expected_error}', actual '{actual_error}'"
+    assert actual_notification_bar_message == expected_notification_bar_message,\
+        f"Notification mismatch: expected '{expected_notification_bar_message}', actual '{actual_notification_bar_message}'"

--- a/tests/test_credentials.py
+++ b/tests/test_credentials.py
@@ -1,7 +1,9 @@
+import time
+
 import pytest
+from selenium.webdriver import Keys
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support.wait import WebDriverWait
-from selenium.webdriver.support import expected_conditions as EC
 
 USERNAME = "Name"
 PASSWORD = "Password"
@@ -73,9 +75,8 @@ def test_create_duplicate_id_error_validation(browser):
     id_field.send_keys(CREDENTIAL_ID)
     browser.execute_script("arguments[0].blur();", id_field)
 
-    actual_error = WebDriverWait(browser, 10).until(
-        lambda d: d.find_element(By.XPATH, "//div[@class='error']").text
-    )
+    browser.find_element(By.NAME, "_.id").send_keys(CREDENTIAL_ID + Keys.TAB)
+    actual_error = browser.find_element(By.XPATH, "//div[@class = 'error']").text
 
     assert actual_error == expected_error, \
         f"Error message mismatch. Expected: '{expected_error}', Actual: '{actual_error}'"
@@ -90,9 +91,8 @@ def test_create_duplicate_id_notification(browser):
     browser.find_element(By.NAME, "_.id").send_keys(CREDENTIAL_ID)
     browser.find_element(By.ID, "cr-dialog-submit").click()
 
-    actual_notification = WebDriverWait(browser, 15).until(
-        lambda d: d.find_element(By.ID, "notification-bar").text
-    )
+    time.sleep(5)
+    actual_notification = browser.find_element(By.ID, "notification-bar").text
 
     assert actual_notification == expected_notification, \
         f"Notification message mismatch. Expected: '{expected_notification}', Actual: '{actual_notification}'"

--- a/tests/test_credentials.py
+++ b/tests/test_credentials.py
@@ -1,7 +1,7 @@
 import pytest
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support.wait import WebDriverWait
-
+from selenium.webdriver.support import expected_conditions as EC
 
 USERNAME = "Name"
 PASSWORD = "Password"
@@ -66,7 +66,7 @@ def test_create(browser):
 @pytest.mark.dependency(depends=["test_create"])
 def test_create_duplicate_id(browser):
     expected_error = "This ID is already in use"
-    expected_notification = "Credentials with specified ID already exist"
+    expected_notification_bar_message = "Credentials with specified ID already exist"
 
     navigate_to_credential_form(browser)
 
@@ -74,15 +74,17 @@ def test_create_duplicate_id(browser):
     id_field.send_keys(CREDENTIAL_ID)
     browser.execute_script("arguments[0].blur();", id_field)
 
-    actual_error = WebDriverWait(browser, 10).until(
-        lambda d: d.find_element(By.XPATH, "//div[@class='error']").text
+    WebDriverWait(browser, 10).until(
+        EC.text_to_be_present_in_element((By.XPATH, "//div[@class='error']"), expected_error)
     )
+    actual_error = browser.find_element(By.XPATH, "//div[@class='error']").text
 
     browser.find_element(By.ID, "cr-dialog-submit").click()
 
-    actual_notification = WebDriverWait(browser, 10).until(
-        lambda d: d.find_element(By.ID, "notification-bar").text
+    WebDriverWait(browser, 10).until(
+        EC.text_to_be_present_in_element((By.ID, "notification-bar"), expected_notification_bar_message)
     )
+    actual_notification_bar_message = browser.find_element(By.ID, "notification-bar").text
 
     assert actual_error == expected_error
-    assert actual_notification == expected_notification
+    assert actual_notification_bar_message == expected_notification_bar_message

--- a/tests/test_credentials.py
+++ b/tests/test_credentials.py
@@ -64,9 +64,8 @@ def test_create(browser):
 
 
 @pytest.mark.dependency(depends=["test_create"])
-def test_create_duplicate_id(browser):
+def test_create_duplicate_id_error_validation(browser):
     expected_error = "This ID is already in use"
-    expected_notification_bar_message = "Credentials with specified ID already exist"
 
     navigate_to_credential_form(browser)
 
@@ -74,17 +73,26 @@ def test_create_duplicate_id(browser):
     id_field.send_keys(CREDENTIAL_ID)
     browser.execute_script("arguments[0].blur();", id_field)
 
-    WebDriverWait(browser, 10).until(
-        EC.text_to_be_present_in_element((By.XPATH, "//div[@class='error']"), expected_error)
+    actual_error = WebDriverWait(browser, 10).until(
+        lambda d: d.find_element(By.XPATH, "//div[@class='error']").text
     )
-    actual_error = browser.find_element(By.XPATH, "//div[@class='error']").text
 
+    assert actual_error == expected_error, \
+        f"Error message mismatch. Expected: '{expected_error}', Actual: '{actual_error}'"
+
+
+@pytest.mark.dependency(depends=["test_create"])
+def test_create_duplicate_id_notification(browser):
+    expected_notification = "Credentials with specified ID already exist"
+
+    navigate_to_credential_form(browser)
+
+    browser.find_element(By.NAME, "_.id").send_keys(CREDENTIAL_ID)
     browser.find_element(By.ID, "cr-dialog-submit").click()
 
-    WebDriverWait(browser, 10).until(
-        EC.text_to_be_present_in_element((By.ID, "notification-bar"), expected_notification_bar_message)
+    actual_notification = WebDriverWait(browser, 15).until(
+        lambda d: d.find_element(By.ID, "notification-bar").text
     )
-    actual_notification_bar_message = browser.find_element(By.ID, "notification-bar").text
 
-    assert actual_error == expected_error
-    assert actual_notification_bar_message == expected_notification_bar_message
+    assert actual_notification == expected_notification, \
+        f"Notification message mismatch. Expected: '{expected_notification}', Actual: '{actual_notification}'"

--- a/tests/test_credentials.py
+++ b/tests/test_credentials.py
@@ -75,11 +75,11 @@ def test_create_duplicate_id_error_validation(browser):
     id_field.send_keys(CREDENTIAL_ID)
     browser.execute_script("arguments[0].blur();", id_field)
 
-    browser.find_element(By.NAME, "_.id").send_keys(CREDENTIAL_ID + Keys.TAB)
-    actual_error = browser.find_element(By.XPATH, "//div[@class = 'error']").text
+    actual_error = WebDriverWait(browser, 10).until(
+        lambda d: d.find_element(By.XPATH, "//div[@class='error']").text
+    )
 
-    assert actual_error == expected_error, \
-        f"Error message mismatch. Expected: '{expected_error}', Actual: '{actual_error}'"
+    assert actual_error == expected_error
 
 
 @pytest.mark.dependency(depends=["test_create"])
@@ -91,8 +91,12 @@ def test_create_duplicate_id_notification(browser):
     browser.find_element(By.NAME, "_.id").send_keys(CREDENTIAL_ID)
     browser.find_element(By.ID, "cr-dialog-submit").click()
 
-    time.sleep(5)
-    actual_notification = browser.find_element(By.ID, "notification-bar").text
+    actual_notification = WebDriverWait(browser, 15).until(
+        lambda d: d.execute_script("""
+                var el = document.getElementById('notification-bar');
+                return el ? el.innerText : '';
+            """)
+    )
 
     assert actual_notification == expected_notification, \
         f"Notification message mismatch. Expected: '{expected_notification}', Actual: '{actual_notification}'"

--- a/tests/test_credentials.py
+++ b/tests/test_credentials.py
@@ -1,6 +1,7 @@
 import pytest
-from selenium.webdriver import Keys
 from selenium.webdriver.common.by import By
+from selenium.webdriver.support.wait import WebDriverWait
+
 
 USERNAME = "Name"
 PASSWORD = "Password"
@@ -61,19 +62,27 @@ def test_create(browser):
 
     assert credential_card.is_displayed(), "Credential card was not found or not visible"
 
+
 @pytest.mark.dependency(depends=["test_create"])
 def test_create_duplicate_id(browser):
     expected_error = "This ID is already in use"
-    expected_notification_bar_message = "Credentials with specified ID already exist"
+    expected_notification = "Credentials with specified ID already exist"
 
     navigate_to_credential_form(browser)
 
-    browser.find_element(By.NAME, "_.id").send_keys(CREDENTIAL_ID + Keys.TAB)
-    actual_error = browser.find_element(By.XPATH, "//div[@class = 'error']").text
+    id_field = browser.find_element(By.NAME, "_.id")
+    id_field.send_keys(CREDENTIAL_ID)
+    browser.execute_script("arguments[0].blur();", id_field)
+
+    actual_error = WebDriverWait(browser, 10).until(
+        lambda d: d.find_element(By.XPATH, "//div[@class='error']").text
+    )
 
     browser.find_element(By.ID, "cr-dialog-submit").click()
-    actual_notification_bar_message = browser.find_element(By.ID, "notification-bar").text
 
-    assert actual_error == expected_error, f"Error message mismatch: expected '{expected_error}', actual '{actual_error}'"
-    assert actual_notification_bar_message == expected_notification_bar_message,\
-        f"Notification mismatch: expected '{expected_notification_bar_message}', actual '{actual_notification_bar_message}'"
+    actual_notification = WebDriverWait(browser, 10).until(
+        lambda d: d.find_element(By.ID, "notification-bar").text
+    )
+
+    assert actual_error == expected_error
+    assert actual_notification == expected_notification

--- a/tests/test_navigate_to_configure_system_page.py
+++ b/tests/test_navigate_to_configure_system_page.py
@@ -1,6 +1,7 @@
+import pytest
 from selenium.webdriver.common.by import By
 
-
+@pytest.mark.skip(reason="ER_10.003.01 | Unstable test on CI")
 def test_navigate_to_configure_system_page(browser):
     manage_jenkins_button = browser.find_element(By.ID, "root-action-ManageJenkinsAction")
     manage_jenkins_button.click()


### PR DESCRIPTION

<img width="2333" height="395" alt="2026-05-03_05-16-40" src="https://github.com/user-attachments/assets/332a811a-3bd8-4117-81d4-90db03e3c665" />

1. Повторяющиеся шаги по переходу к форме создания учетных данных вынесены в отдельную функцию navigate_to_credential_form. (планирую сделать рефакторинг test_create и тоже там ее использовать)

2. Добавлен зависимый тест test_create_duplicate_id_error_validation, который проверяет, что нельзя создать два одинаковых credentials с одним ID. Он проверяет валидацию поля ID и ожидает, что вернется ошибка "This ID is already in use"

3. Тут много коммитов, потому что изначально тут должно было быть две проверки, вторая заключалась в поиске появления notification-bar с ошибкой, но на CI он не появляется или я не могу его найти.