### PR TITLE
RF_16.010.01 | Freestyle Project Management > Rename Project > Opening Rename Project page from Dashboard

### DIFF
--- a/tests/test_freestyle_project.py
+++ b/tests/test_freestyle_project.py
@@ -1,9 +1,14 @@
 from selenium.webdriver.common.by import By
+import time
+from selenium.webdriver.support.ui import WebDriverWait
+from selenium.webdriver.support import expected_conditions as EC
+import pytest
 
-FREESTYLE_PROJECT_NAME = "Freestyle Project"
+FREESTYLE_PROJECT_NAME = f"freestyle_project_{int(time.time())}"
 description = "Description Freestyle Project"
 
 
+@pytest.mark.dependency()
 def test_create_freestyle_project(browser):
     browser.find_element(By.XPATH, "//a[@href='/view/all/newJob']").click()
     browser.find_element(By.ID, "name").send_keys(FREESTYLE_PROJECT_NAME)
@@ -14,3 +19,14 @@ def test_create_freestyle_project(browser):
     assert browser.find_element(By.ID, "description-content").text == description
 
     assert browser.find_element(By.CSS_SELECTOR, ".job-index-headline.page-headline").text == FREESTYLE_PROJECT_NAME
+
+
+@pytest.mark.dependency(depends=["test_create_freestyle_project"])
+def test_rename_freestyle_project_page_from_dashboard(browser):
+    wait = WebDriverWait(browser, 5)
+    wait.until(EC.element_to_be_clickable((By.CLASS_NAME, 'app-jenkins-logo'))).click()
+    wait.until(EC.visibility_of_element_located((By.CSS_SELECTOR, f'[href="job/{FREESTYLE_PROJECT_NAME}/"]>.jenkins-menu-dropdown-chevron'))).click()
+    wait.until(EC.visibility_of_element_located((By.PARTIAL_LINK_TEXT, 'Rename'))).click()
+
+    rename_page_title = wait.until(EC.visibility_of_element_located((By.TAG_NAME, 'h1'))).text
+    assert rename_page_title == f'Rename Project {FREESTYLE_PROJECT_NAME}'

--- a/tests/test_freestyle_project.py
+++ b/tests/test_freestyle_project.py
@@ -1,10 +1,9 @@
 from selenium.webdriver.common.by import By
-import time
 from selenium.webdriver.support.ui import WebDriverWait
 from selenium.webdriver.support import expected_conditions as EC
 import pytest
 
-FREESTYLE_PROJECT_NAME = f"freestyle_project_{int(time.time())}"
+FREESTYLE_PROJECT_NAME = "freestyle_project"
 description = "Description Freestyle Project"
 
 

--- a/tests/test_rename_project_page.py
+++ b/tests/test_rename_project_page.py
@@ -14,14 +14,6 @@ def create_new_freestyle_project(driver):
     wait.until(EC.element_to_be_clickable((By.CLASS_NAME, 'app-jenkins-logo'))).click()
     return project_name
 
-def test_rename_freestyle_project_from_dashboard(browser):
-    wait = WebDriverWait(browser, 5)
-    project_name = create_new_freestyle_project(browser)
-    wait.until(EC.visibility_of_element_located((By.CSS_SELECTOR, f'[href="job/{project_name}/"]>.jenkins-menu-dropdown-chevron'))).click()
-    wait.until(EC.visibility_of_element_located((By.PARTIAL_LINK_TEXT, 'Rename'))).click()
-    rename_page_title = wait.until(EC.visibility_of_element_located((By.TAG_NAME, 'h1')))
-    assert rename_page_title.text == f'Rename Project {project_name}'
-
 def test_rename_freestyle_project_from_project_page(browser):
     wait = WebDriverWait(browser, 5)
     project_name = create_new_freestyle_project(browser)


### PR DESCRIPTION
1. Move "test_rename_freestyle_project_from_dashboard" test from "test_rename_project_page" module to "test_freestyle_project" module
2. Make list of tests
3. Refactor FREESTYLE_PROJECT_NAME in "test_freestyle_project" to adopt it to "test_rename_project_page" test