### PR TITLE
RF_08.002.04 | Sign in/out > Sign out > test_sign_out to POM

### DIFF
--- a/pages/home_page.py
+++ b/pages/home_page.py
@@ -22,25 +22,11 @@ class HomePage(BasePage):
 
         return self
 
-    def dropdown_menu_item_click(self, name):
-        items = {
-            "Theme": {},
-            "My views": {},
-            "Account": {},
-            "Appearance": {},
-            "Preferences": {},
-            "Security": {},
-            "Experiments": {},
-            "Credentials": {},
-            "Sign out": {
-                "xpath": '//div[@class="jenkins-dropdown"]//a[@href="/logout"]',
-                "result page": LoginPage,
-            },
-        }
-
+    def dropdown_menu_sign_out_click(self):
         self.wait10.until(
-            EC.element_to_be_clickable((By.XPATH, items[name]["xpath"]))
+            EC.element_to_be_clickable(
+                (By.XPATH, '//div[@class="jenkins-dropdown"]//a[@href="/logout"]')
+            )
         ).click()
-        current_page = items[name]["result page"]
 
-        return current_page(self.driver)
+        return LoginPage(self.driver)

--- a/pages/home_page.py
+++ b/pages/home_page.py
@@ -1,8 +1,10 @@
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support import expected_conditions as EC
+from selenium.webdriver.common.action_chains import ActionChains
 
 from pages.base_page import BasePage
 from pages.new_item_page import NewItemPage
+from pages.login_page import LoginPage
 
 
 class HomePage(BasePage):
@@ -12,3 +14,33 @@ class HomePage(BasePage):
         ).click()
 
         return NewItemPage(self.driver)
+
+    def show_dropdown_menu_from_profile_icon(self):
+        ActionChains(self.driver).move_to_element(
+            self.driver.find_element(By.ID, "root-action-UserAction")
+        ).perform()
+
+        return self
+
+    def dropdown_menu_item_click(self, name):
+        items = {
+            "Theme": {},
+            "My views": {},
+            "Account": {},
+            "Appearance": {},
+            "Preferences": {},
+            "Security": {},
+            "Experiments": {},
+            "Credentials": {},
+            "Sign out": {
+                "xpath": '//div[@class="jenkins-dropdown"]//a[@href="/logout"]',
+                "result page": LoginPage,
+            },
+        }
+
+        self.wait10.until(
+            EC.element_to_be_clickable((By.XPATH, items[name]["xpath"]))
+        ).click()
+        current_page = items[name]["result page"]
+
+        return current_page(self.driver)

--- a/pages/login_page.py
+++ b/pages/login_page.py
@@ -1,0 +1,13 @@
+from selenium.webdriver.common.by import By
+from pages.base_page import BasePage
+
+
+class LoginPage(BasePage):
+    def get_username_field(self):
+        return self.driver.find_element(By.ID, "j_username").get_attribute("value")
+
+    def get_password_field(self):
+        return self.driver.find_element(By.ID, "j_password").get_attribute("value")
+
+    def get_title(self):
+        return self.driver.title

--- a/tests/test_sign_in_sign_out_2.py
+++ b/tests/test_sign_in_sign_out_2.py
@@ -12,7 +12,7 @@ def test_sign_out(browser):
     login_page = (
         HomePage(browser)
         .show_dropdown_menu_from_profile_icon()
-        .dropdown_menu_item_click("Sign out")
+        .dropdown_menu_sign_out_click()
     )
 
     assert login_page.get_title() == LOGIN_PAGE_TITLE

--- a/tests/test_sign_in_sign_out_2.py
+++ b/tests/test_sign_in_sign_out_2.py
@@ -1,27 +1,24 @@
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support.ui import WebDriverWait
 from selenium.webdriver.support import expected_conditions as EC
-from selenium.webdriver.common.action_chains import ActionChains
 from os import getenv
 from common.jenkins_utils import logout
+from pages.home_page import HomePage
+
+LOGIN_PAGE_TITLE = "Sign in - Jenkins"
 
 
 def test_sign_out(browser):
-    wait = WebDriverWait(browser, 5)
+    login_page = (
+        HomePage(browser)
+        .show_dropdown_menu_from_profile_icon()
+        .dropdown_menu_item_click("Sign out")
+    )
 
-    ActionChains(browser).move_to_element(
-        browser.find_element(By.ID, "root-action-UserAction")
-    ).perform()
-    wait.until(
-        EC.element_to_be_clickable(
-            (By.XPATH, '//div[@class="jenkins-dropdown"]//a[@href="/logout"]')
-        )
-    ).click()
+    assert login_page.get_title() == LOGIN_PAGE_TITLE
 
-    assert browser.title == "Sign in - Jenkins"
-
-    assert browser.find_element(By.ID, "j_username").get_attribute("value") == ""
-    assert browser.find_element(By.ID, "j_password").get_attribute("value") == ""
+    assert login_page.get_username_field() == ""
+    assert login_page.get_password_field() == ""
 
 
 def test_sign_in_with_valid_username_and_password(browser):


### PR DESCRIPTION
- Add methods show_dropdown_menu_from_profile_icon and dropdown_menu_sign_out_click to the HomePage class
- Add the LoginPage class and its three methods get_username_field, get_password_field and get_title
- Refactor test_sign_out to comply with the POM pattern
- Сhange the file name test_sign_in_sign_out2 to test_sign_in_sign_out_2