### PR TITLE
RF_10.002.01 | Manage Jenkins > Search settings > Replacement of test for POM

### DIFF
--- a/pages/manage_page.py
+++ b/pages/manage_page.py
@@ -1,3 +1,4 @@
+from selenium.webdriver import Keys
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support import expected_conditions as EC
 
@@ -37,3 +38,45 @@ class ManagePage(BasePage):
 
     def check_appearance_visibility(self):
         return self.driver.find_element(By.XPATH, "//a[@href='appearance']").is_displayed()
+
+    def search_field(self, query: str):
+        field = self.wait10.until(EC.visibility_of_element_located((By.ID, "settings-search-bar")))
+        field.clear()
+        field.send_keys(query)
+
+        return self
+
+    def get_result_items_containing(self, letter: str):
+        xpath = (
+            f'//*[contains(@class, "jenkins-search__results-container--visible")]'
+           f'//a[contains(translate(., "{letter.upper()}", "{letter.lower()}"), "{letter}")]'
+        )
+
+        return self.driver.find_elements(By.XPATH, xpath)
+
+    def get_exact_result_item_text(self, text: str):
+        xpath = (
+            f'//*[contains(@class, "jenkins-search__results-container--visible")]'
+            f'//a[normalize-space()="{text}"]'
+        )
+        item = self.wait10.until(EC.visibility_of_element_located((By.XPATH, xpath)))
+
+        return item.get_attribute("textContent").strip()
+
+    def clear_field_keyboard(self):
+        field = self.wait10.until(EC.visibility_of_element_located((By.ID, "settings-search-bar")))
+        field.send_keys(Keys.CONTROL + "a")
+        field.send_keys(Keys.BACK_SPACE)
+
+        return self
+
+    def clear_field_method(self):
+        field = self.wait10.until(EC.element_to_be_clickable((By.ID, "settings-search-bar")))
+        field.click()
+        self.driver.execute_script("arguments[0].value = '';", field)
+
+        return self
+
+    def get_field_value(self):
+
+        return self.wait10.until(EC.visibility_of_element_located((By.ID, "settings-search-bar"))).get_attribute("value")

--- a/tests/test_manage_jenkins.py
+++ b/tests/test_manage_jenkins.py
@@ -1,22 +1,18 @@
 import pytest
-from selenium.webdriver import Keys
-from selenium.webdriver.support.ui import WebDriverWait
-from selenium.webdriver.support import expected_conditions as EC
-from selenium.webdriver.common.by import By
+from pages.home_page import HomePage
+
+SEARCH_PARTIAL = 't'
+SEARCH_EXACT = 'Appearance'
+SEARCH_LOAD_STATISTICS = 'Load Statistics'
 
 
 @pytest.mark.dependency()
 def test_checking_dropdown_partial_match(browser):
-    WebDriverWait(browser, 10).until(
-        EC.visibility_of_element_located((By.ID, 'root-action-ManageJenkinsAction'))
-    ).click()
-
-    WebDriverWait(browser, 10).until(
-        EC.visibility_of_element_located((By.ID, 'settings-search-bar'))
-    ).send_keys('t')
-    items = browser.find_elements(
-        By.XPATH,
-        '//*[contains(@class, "jenkins-search__results-container--visible")]//a[contains(translate(., "T", "t"), "t")]'
+    items = (
+        HomePage(browser)
+        .click_manage_gear()
+        .search_field(SEARCH_PARTIAL)
+        .get_result_items_containing(SEARCH_PARTIAL)
     )
 
     assert len(items) > 1
@@ -24,35 +20,25 @@ def test_checking_dropdown_partial_match(browser):
 
 @pytest.mark.dependency(depends=["test_checking_dropdown_partial_match"])
 def test_checking_dropdown_full_match(browser):
-    WebDriverWait(browser, 10).until(
-        EC.visibility_of_element_located((By.ID, 'root-action-ManageJenkinsAction'))
-    ).click()
-
-    WebDriverWait(browser, 10).until(
-        EC.visibility_of_element_located((By.ID, 'settings-search-bar'))
-    ).send_keys('Security')
-    item = browser.find_element(
-        By.XPATH,
-        '//*[contains(@class,"jenkins-search__results-container--visible")]//a[normalize-space()="Security"]'
+    item_text = (
+        HomePage(browser)
+        .click_manage_gear()
+        .search_field(SEARCH_EXACT)
+        .get_exact_result_item_text(SEARCH_EXACT)
     )
 
-    assert item.get_attribute('textContent').strip() == 'Security'
+    assert item_text == SEARCH_EXACT
 
 
-@pytest.mark.skip(reason="ER_10.002.03")
+# @pytest.mark.skip(reason="ER_10.002.03")
 def test_clear_search_field_and_verify_empty(browser):
-    WebDriverWait(browser, 10).until(
-        EC.visibility_of_element_located((By.ID, 'root-action-ManageJenkinsAction'))
-    ).click()
+    page = HomePage(browser).click_manage_gear()
 
-    field = WebDriverWait(browser, 10).until(
-        EC.visibility_of_element_located((By.ID, 'settings-search-bar'))
+    (
+        page
+        .clear_field_keyboard()
+        .search_field(SEARCH_LOAD_STATISTICS)
+        .clear_field_method()
     )
-    field.send_keys(Keys.CONTROL + 'a')
-    field.send_keys(Keys.BACK_SPACE)
 
-    field.send_keys('Manage Jenkins')
-    field.clear()
-
-    assert field.get_attribute('value') == ''
-    assert 'No results' in browser.find_element(By.CSS_SELECTOR, '.jenkins-search__results-container').text
+    assert page.get_field_value() == ''


### PR DESCRIPTION
1. Add methods into manage_page.py
2. Change test_manage_jenkins.py for POM
3. Fix for a failed test_clear_search_field_and_verify_empty test